### PR TITLE
ci: minimal permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: ci
 on: pull_request
+permissions:
+  contents: read
 jobs:
   check-signatures:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It is recommended to limit the permissions to the minimal required